### PR TITLE
Fix for Issue #25

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -1,4 +1,5 @@
 var vscode = require('vscode');
+var os = require("os");
 var window = vscode.window;
 var workspace = vscode.workspace;
 
@@ -175,7 +176,7 @@ function showOutputChannel(data) {
         // due to an issue of vscode(https://github.com/Microsoft/vscode/issues/586), in order to make file path clickable within the output channel,the file path differs from platform
         //for windows and mac
         var path = '#' + (i + 1) + '\t' + v.uri + '#' + (v.lineNum + 1);
-        if (changeFilePattern) {
+        if (os.platform() == "linux") {
             // for linux
             path = '#' + (i + 1) + '\t\t' + v.uri + ':' + (v.lineNum + 1) + ':' + (v.startCol + 1);
         }


### PR DESCRIPTION
Automatically Detect platform and log File Path Accordingly so that the link is clickable from VSCode Output Console.