### PR TITLE
Added .tsx files inside default todohighlight.include.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ following is an example of configuration:
         "backgroundColor": "yellow",
         "overviewRulerColor": "grey"
     },
-    "todohighlight.include": "{**/*.js,**/*.jsx,**/*.ts,**/*.html,**/*.php,**/*.css,**/*.scss}", //A glob pattern that defines the files to search for. Only include files you need, DO NOT USE `{**/*.*}` for both permormance and avoiding binary files reason
+    "todohighlight.include": "{**/*.js,**/*.jsx,**/*.ts,**/*.tsx,**/*.html,**/*.php,**/*.css,**/*.scss}", //A glob pattern that defines the files to search for. Only include files you need, DO NOT USE `{**/*.*}` for both permormance and avoiding binary files reason
     "todohighlight.exclude": "{**/node_modules/**,**/bower_components/**,**/dist/**,**/build/**,**/.vscode/**,**/_output/**,**/*.min.*,**/*.map}",//A glob pattern that defines files and folders to exclude while listing annotations
     "todohighlight.maxFilesForSearch": 5120,//Max files for searching, mostly you don't need to configure this
     "todohighlight.toggleURI": false,//If the file path within the output channel not clickable, set this to true to toggle the path patten between `<path>#<line>` and `<path>:<line>:<column>`

--- a/package.json
+++ b/package.json
@@ -156,7 +156,7 @@
                 },
                 "todohighlight.include": {
                     "type": "string",
-                    "default": "{**/*.js,**/*.jsx,**/*.ts,**/*.html,**/*.php,**/*.css,**/*.scss}",
+                    "default": "{**/*.js,**/*.jsx,**/*.ts,**/*.tsx,**/*.html,**/*.php,**/*.css,**/*.scss}",
                     "description": "A glob pattern that defines the files to search for. Only include files you need, DO NOT USE `**/*.*` for both permormance and avoiding binary files reason"
                 },
                 "todohighlight.exclude": {


### PR DESCRIPTION
Since todo-highlight supports .jsx and .ts by default, i figured we should add .tsx in the defaults as well.

Because it caused me to figure out why my todos were not highlighted. 

(Though it would be in there by default since .ts and .jsx worked)