### PR TITLE
searchAnnotations: run callback even if one or more files failed

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -98,17 +98,14 @@ function searchAnnotations(workspaceState, pattern, callback) {
                 progress = Math.floor((times / totalFiles) * 100);
 
                 setStatusMsg(zapIcon, progress + '% ' + statusMsg);
-
-                if (times === totalFiles || window.manullyCancel) {
-                    window.processing = true;
-                    workspaceState.update('annotationList', annotationList)
-                    callback(null, annotations, annotationList);
-                }
             }, function (err) {
                 errorHandler(err);
             });
 
         }
+        workspaceState.update('annotationList', annotationList);
+        callback(null, annotations, annotationList);
+        
     }, function (err) {
         errorHandler(err);
     });


### PR DESCRIPTION
See #75: Finish the list highlighted annotations action, even if one of the matched files is a binary.

Also I'm not sure about `window.manullyCancel` and `window.processing`, I think they both dont really do anything?

Fixes #75 and is most probably related to #35.
Does not have anything to do with / does not fix the crashing issues.