### PR TITLE
searchAnnotations: run callback even if one or more files failed

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -98,17 +98,14 @@ function searchAnnotations(workspaceState, pattern, callback) {
                 progress = Math.floor((times / totalFiles) * 100);
 
                 setStatusMsg(zapIcon, progress + '% ' + statusMsg);
-
-                if (times === totalFiles || window.manullyCancel) {
-                    window.processing = true;
-                    workspaceState.update('annotationList', annotationList)
-                    callback(null, annotations, annotationList);
-                }
             }, function (err) {
                 errorHandler(err);
             });
 
         }
+        workspaceState.update('annotationList', annotationList);
+        callback(null, annotations, annotationList);
+        
     }, function (err) {
         errorHandler(err);
     });

--- a/src/util.js
+++ b/src/util.js
@@ -90,21 +90,30 @@ function searchAnnotations(workspaceState, pattern, callback) {
             annotations = {},
             annotationList = [];
 
+        function file_iterated() {
+            times++;
+            progress = Math.floor(times / totalFiles * 100);
+
+            setStatusMsg(zapIcon, progress + '% ' + statusMsg);
+
+            if (times === totalFiles || window.manullyCancel) {
+                window.processing = true;
+                workspaceState.update('annotationList', annotationList);
+                callback(null, annotations, annotationList);
+            }
+        }
+
         for (var i = 0; i < totalFiles; i++) {
 
             workspace.openTextDocument(files[i]).then(function (file) {
                 searchAnnotationInFile(file, annotations, annotationList, pattern);
-                times++;
-                progress = Math.floor((times / totalFiles) * 100);
-
-                setStatusMsg(zapIcon, progress + '% ' + statusMsg);
+                file_iterated();
             }, function (err) {
                 errorHandler(err);
+                file_iterated();
             });
 
         }
-        workspaceState.update('annotationList', annotationList);
-        callback(null, annotations, annotationList);
         
     }, function (err) {
         errorHandler(err);


### PR DESCRIPTION
2nd try, this time with working code.

See #75: Finish the list highlighted annotations action, even if one of the matched files is a binary.

Also I'm not sure about window.manullyCancel and window.processing, I think they both dont really do anything?

Fixes #75 and is most probably related to #35.
Does not have anything to do with / does not fix the crashing issues.