### PR TITLE
Allow full lines to be highlighted

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ To customize the keywords and other stuff, <kbd>command</kbd> + <kbd>,</kbd> (Wi
 | todohighlight.exclude | array | [<br>`"**/node_modules/**"`,<br>`"**/dist/**",`<br>`"**/bower_components/**"`,<br>`"**/build/**",`<br>`"**/.vscode/**"`,<br>`"**/.github/**"`,<br>`"**/_output/**"`,<br>`"**/*.min.*"`,<br>`"**/*.map"`<br>] | Glob pattern that defines files and folders to exclude while listing annotations. <br> For backwards compatability, a string combine all the patterns is also valid `"{**/node_modules/**,**/bower_components/**,**/dist/**,**/build/**,**/.vscode/**,**/_output/**,**/*.min.*,**/*.map}"` |
 | todohighlight.maxFilesForSearch | number | 5120 | Max files for searching, mostly you don't need to configure this. |
 | todohighlight.toggleURI | boolean | false | If the file path within the output channel not clickable, set this to true to toggle the path patten between `<path>#<line>` and `<path>:<line>:<column>`. |
+| todohighlight.fullLine | boolean | false | If set to true, not only the label but any text following it will be highlighted. |
 
 
 an example of customizing configuration:

--- a/package.json
+++ b/package.json
@@ -204,6 +204,11 @@
                     "type": "number",
                     "default": 5120,
                     "description": "Max files for searching"
+                },
+                "todohighlight.fullLine": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "If set to true, not only the label but any text following it will be highlighted."
                 }
             }
         }

--- a/src/extension.js
+++ b/src/extension.js
@@ -87,7 +87,13 @@ function activate(context) {
         var mathes = {}, match;
         while (match = pattern.exec(text)) {
             var startPos = activeEditor.document.positionAt(match.index);
-            var endPos = activeEditor.document.positionAt(match.index + match[0].length);
+            var endPos;
+            if (settings.get('fullLine', false)) {
+                endPos = activeEditor.document.lineAt(startPos).range.end;
+            } else {
+                endPos = activeEditor.document.positionAt(match.index + match[0].length);
+            }
+
             var decoration = {
                 range: new vscode.Range(startPos, endPos)
             };

--- a/src/extension.js
+++ b/src/extension.js
@@ -84,7 +84,7 @@ function activate(context) {
         }
 
         var text = activeEditor.document.getText();
-        var mathes = {}, match;
+        var mathes = {}, match, prevEndPos;
         while (match = pattern.exec(text)) {
             var startPos = activeEditor.document.positionAt(match.index);
             var endPos;
@@ -93,6 +93,11 @@ function activate(context) {
             } else {
                 endPos = activeEditor.document.positionAt(match.index + match[0].length);
             }
+
+            if (prevEndPos && prevEndPos.compareTo(startPos) >= 0) {
+                continue;
+            }
+            prevEndPos = endPos;
 
             var decoration = {
                 range: new vscode.Range(startPos, endPos)


### PR DESCRIPTION
I always wanted the option to have full lines with a certain label highlighted so I thought to myself I could start implementing that. However, I'm a total vscode development newbie.

This PR should outline my idea but worked when tested. However, there are two issues.

- [x] When two labels overlap, only the first one is highlighted. It would be better if the last label would only highlight the line until it encounters the next one but I think this would only be achievable with some kind of lookback or with delayed iteration, i. e. you hold two variables in the "`match-loop`", `match` and `prevMatch`.
- [x] I don't know how to add my new setting such that it appears when you search for it.