### PR TITLE
Feat: RegEx in keywords

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.vscode-test

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,7 +15,11 @@
             "type": "extensionHost",
             "request": "launch",
             "runtimeExecutable": "${execPath}",
-            "args": ["--extensionDevelopmentPath=${workspaceRoot}", "--extensionTestsPath=${workspaceRoot}/test" ],
+            "args": [
+                "--disable-extensions",
+                "--extensionDevelopmentPath=${workspaceRoot}",
+                "--extensionTestsPath=${workspaceRoot}/test"
+            ],
             "stopOnEntry": false
         }
     ]

--- a/README.md
+++ b/README.md
@@ -41,8 +41,7 @@ To customize the keywords and other stuff, <kbd>command</kbd> + <kbd>,</kbd> (Wi
 | todohighlight.maxFilesForSearch | number | 5120 | Max files for searching, mostly you don't need to configure this. |
 | todohighlight.toggleURI | boolean | false | If the file path within the output channel not clickable, set this to true to toggle the path patten between `<path>#<line>` and `<path>:<line>:<column>`. |
 
-
-an example of customizing configuration:
+An example of customizing configuration:
 
 ```js
 {
@@ -56,6 +55,15 @@ an example of customizing configuration:
             "color": "#ff0000",
             "backgroundColor": "yellow",
             "overviewRulerColor": "grey"
+            "regex": { // Override the text search pattern with your custom RegEx pattern
+                "pattern": "(?<=^|\s|\/)NOTE[:]?" // highlight `NOTE:` with or without the `:` and that's not part of another word.
+                // (I.e.: The above will highlight 'NOTE' but not the "note" in 'SIDENOTE').
+                /**
+                 * NOTE:
+                 * Positive lookbehind (`(?<=...)`) is only supported in Node.js v9 and up.
+                 * If your VSCode version is built on a later version the example above may not work.
+                 **/
+            }
         },
         {
             "text": "HACK:",

--- a/package.json
+++ b/package.json
@@ -125,6 +125,11 @@
                                     "overviewRulerColor": {
                                         "type": "string",
                                         "description": "The color of the ruler mark on the scroll bar. Use rgba() and define transparent colors to play well with other decorations. See all available properties on VSCode doc DecorationRenderOptions section: https://code.visualstudio.com/docs/extensionAPI/vscode-api"
+                                    },
+                                    "useRegexp": {
+                                        "type": "boolean",
+                                        "description": "Wether to treat the text field as RegExp or not",
+                                        "default": false
                                     }
                                 }
                             }

--- a/package.json
+++ b/package.json
@@ -126,9 +126,9 @@
                                         "type": "string",
                                         "description": "The color of the ruler mark on the scroll bar. Use rgba() and define transparent colors to play well with other decorations. See all available properties on VSCode doc DecorationRenderOptions section: https://code.visualstudio.com/docs/extensionAPI/vscode-api"
                                     },
-                                    "useRegexp": {
+                                    "useRegex": {
                                         "type": "boolean",
-                                        "description": "Wether to treat the text field as RegExp or not",
+                                        "description": "Wether to treat the text field as RegEx pattern or not",
                                         "default": false
                                     }
                                 }

--- a/package.json
+++ b/package.json
@@ -126,10 +126,11 @@
                                         "type": "string",
                                         "description": "The color of the ruler mark on the scroll bar. Use rgba() and define transparent colors to play well with other decorations. See all available properties on VSCode doc DecorationRenderOptions section: https://code.visualstudio.com/docs/extensionAPI/vscode-api"
                                     },
-                                    "useRegex": {
-                                        "type": "boolean",
-                                        "description": "Wether to treat the text field as RegEx pattern or not",
-                                        "default": false
+                                    "regex": {
+                                        "pattern": {
+                                            "type": "string",
+                                            "description": "The RegEx pattern to use for matching instead of the text value"
+                                        }
                                     }
                                 }
                             }

--- a/src/extension.js
+++ b/src/extension.js
@@ -108,11 +108,28 @@ function activate(context) {
             }
         }
 
+        var typedMatches = {};
         Object.keys(decorationTypes).forEach((v) => {
             if (!isCaseSensitive) {
                 v = v.toUpperCase();
             }
-            var rangeOption = settings.get('isEnable') && mathes[v] ? mathes[v] : [];
+
+            // FIXME: Can this be solved better than with a double for loop?
+
+            Object.keys(mathes).map(m => {
+                let reg = isCaseSensitive ? new RegExp(v, 'g') : new RegExp(v, 'gi');
+                if (m.match(reg) !== null) {
+                    if (!typedMatches[v]) {
+                        typedMatches[v] = mathes[m];
+                    } else {
+                        typedMatches[v] = typedMatches[v].concat(mathes[m]);
+                    }
+                }
+            })
+        });
+
+        Object.keys(typedMatches).forEach(v => {
+            var rangeOption = settings.get('isEnable') && typedMatches[v] ? typedMatches[v] : [];
             var decorationType = decorationTypes[v];
             activeEditor.setDecorations(decorationType, rangeOption);
         })
@@ -157,7 +174,11 @@ function activate(context) {
             });
 
             pattern = Object.keys(assembledData).map((v) => {
-                return util.escapeRegExp(v);
+                if (!assembledData[v].useRegexp) {
+                    return util.escapeRegExp(v);
+                }
+
+                return v
             }).join('|');
         }
 

--- a/src/util.js
+++ b/src/util.js
@@ -43,8 +43,8 @@ function getAssembledData(keywords, customDefaultStyle, isCaseSensitive) {
         }
         result[text] = Object.assign({}, DEFAULT_STYLE, customDefaultStyle, v);
 
-        if (v.useRegex) {
-            regex.push(text);
+        if (v.regex) {
+            regex.push(regex.pattern||text);
         }
     })
 

--- a/src/util.js
+++ b/src/util.js
@@ -271,8 +271,13 @@ function escapeRegExpGroups(s) {
         // Make group non-capturing
         return s.replace(grpPattern, '$1?:$2$3');
     } else {
-        return s.replace(/[()]/g, '\\$&').replace(/[\\]{2}(\(|\))/g, '\\$1');
+        return escapeRegExpGroupsLegacy(s);
     }
+}
+
+function escapeRegExpGroupsLegacy(s) {
+    return s.replace(/\(\?<[=|!][^)]*\)/g, '') // Remove any unsupported lookbehinds
+        .replace(/(\((?!\?[:|=|!]))([^)]*)(\))/g, '$1?:$2$3'); // Make all groups non-capturing
 }
 
 module.exports = {
@@ -285,5 +290,6 @@ module.exports = {
     setStatusMsg,
     showOutputChannel,
     escapeRegExp,
-    escapeRegExpGroups
+    escapeRegExpGroups,
+    escapeRegExpGroupsLegacy
 };

--- a/src/util.js
+++ b/src/util.js
@@ -277,7 +277,7 @@ function escapeRegExpGroups(s) {
 
 function escapeRegExpGroupsLegacy(s) {
     return s.replace(/\(\?<[=|!][^)]*\)/g, '') // Remove any unsupported lookbehinds
-        .replace(/(\((?!\?[:|=|!]))([^)]*)(\))/g, '$1?:$2$3'); // Make all groups non-capturing
+        .replace(/((?:[^\\]{1}|^)(?:(?:[\\]{2})+)?)(\((?!\?[:|=|!]))([^)]*)(\))/g, '$1$2?:$3$4'); // Make all groups non-capturing
 }
 
 module.exports = {

--- a/test/extension.test.js
+++ b/test/extension.test.js
@@ -11,7 +11,7 @@ var assert = require('assert');
 // You can import and use all API from the 'vscode' module
 // as well as import your extension to test it
 var vscode = require('vscode');
-var myExtension = require('../extension');
+var extension = require('../src/extension');
 
 // Defines a Mocha test suite to group tests of similar kind together
 suite("Extension Tests", function() {

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -1,0 +1,21 @@
+/* global suite, test */
+const assert = require('assert');
+const util = require('../src/util');
+
+suite('Util Tests', () => {
+
+	test('Escape RegEx', () => {
+		let res = util.escapeRegExp('^(Hello)|Wonderf[u]l(?:Regex){2}\A/B[c]+[0-9]*.$');
+		assert.equal('\\^\\(Hello\\)\\|Wonderf\\[u\\]l\\(\\?:Regex\\)\\{2\\}A\\/B\\[c\\]\\+\\[0\\-9\\]\\*\\.\\$', res);
+	});
+
+	test('Escape RegEx Groups', () => {
+		let res = util.escapeRegExpGroups('^(Hello)|Wonderf[u]l(?:Regex){2}\A/B[c]+[0-9]*.$')
+		if (parseFloat(process.version.replace('v', '')) > 9.0) {
+			assert.equal('^(?:Hello)|Wonderf[u]l(?:Regex){2}\A/B[c]+[0-9]*.$', res);
+		} else {
+			assert.equal('^\\(Hello\\)|Wonderf[u]l\\(?:Regex\\){2}\A/B[c]+[0-9]*.$', res);
+		}
+	});
+
+});

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -4,18 +4,91 @@ const util = require('../src/util');
 
 suite('Util Tests', () => {
 
-	test('Escape RegEx', () => {
-		let res = util.escapeRegExp('^(Hello)|Wonderf[u]l(?:Regex){2}\A/B[c]+[0-9]*.$');
-		assert.equal('\\^\\(Hello\\)\\|Wonderf\\[u\\]l\\(\\?:Regex\\)\\{2\\}A\\/B\\[c\\]\\+\\[0\\-9\\]\\*\\.\\$', res);
+	// Test util.escapeRegExp
+	suite('Escape RegEx', () => {
+
+		test ("RegEx characters should be properly escaped", () => {
+			let res = util.escapeRegExp('^(Hello)|Wonderf[u]l(?:Regex){2}\A/B[c]+[0-9]*.$');
+			assert.equal('\\^\\(Hello\\)\\|Wonderf\\[u\\]l\\(\\?:Regex\\)\\{2\\}A\\/B\\[c\\]\\+\\[0\\-9\\]\\*\\.\\$', res);
+		});
+
 	});
 
-	test('Escape RegEx Groups', () => {
-		let res = util.escapeRegExpGroups('^(Hello)|Wonderf[u]l(?:Regex){2}\A/B[c]+[0-9]*.$')
-		if (parseFloat(process.version.replace('v', '')) > 9.0) {
-			assert.equal('^(?:Hello)|Wonderf[u]l(?:Regex){2}\A/B[c]+[0-9]*.$', res);
-		} else {
-			assert.equal('^\\(Hello\\)|Wonderf[u]l\\(?:Regex\\){2}\A/B[c]+[0-9]*.$', res);
-		}
+	// Test util.escapeRegExpGroups (if Node.js version > 9.0)
+	if (parseFloat(process.version.replace('v', '')) > 9.0) {
+		suite('Escape RegEx Groups', () => {
+
+			test('Capturing groups should be turned into non-capturing ones', () => {
+				let res = util.escapeRegExpGroups('(Hello) (World)');
+				assert.equal(res, '(?:Hello) (?:World)');
+			});
+
+			test('Escaped parantheses should be ignored', () => {
+				let res = util.escapeRegExpGroups('\\(Hello\\) \\(World\\)');
+				assert.equal(res, '\\(Hello\\) \\(World\\)');
+			});
+
+			test('Non-capturing groups should be ignored', () => {
+				let res = util.escapeRegExpGroups('(?:Hello) (?:World)');
+				assert.equal(res, '(?:Hello) (?:World)');
+			});
+
+			test('Lookbehind and lookaheads should be ignored', () => {
+				let res = util.escapeRegExpGroups('(?=Hello) (?<!World)');
+				assert.equal(res, '(?=Hello) (?<!World)');
+			});
+
+			test('Groups preceded by one or multiple escaped backslashes (\\) should not be ignored', () => {
+				let res = util.escapeRegExpGroupsLegacy('\\\\(Hello) \\\\\\\\(World)');
+				assert.equal(res, '\\\\(?:Hello) \\\\\\\\(?:World)');
+			});
+
+			test('Mixing lookaheads, lookbehind and groups should still behave as expected', () => {
+				let res = util.escapeRegExpGroups('^(Hello) (?!World)|(?<=Won)derf[u]l(?:Regex){2}\A/B[c]+[0-9]*.$');
+				assert.equal('^(?:Hello) (?!World)|(?<=Won)derf[u]l(?:Regex){2}\A/B[c]+[0-9]*.$', res);
+			});
+			
+		});
+	}
+
+	// Test util.escapeRegExpGroupsLegacy
+	suite('Escape RegEx Groups (Legacy Version)', () => {
+
+		test('Capturing groups should be turned into non-capturing ones', () => {
+			let res = util.escapeRegExpGroupsLegacy('(Hello) (World)');
+			assert.equal(res, '(?:Hello) (?:World)');
+		});
+
+		test('Escaped parantheses should be ignored', () => {
+			let res = util.escapeRegExpGroupsLegacy('\\(Hello\\) \\(World\\)');
+			assert.equal(res, '\\(Hello\\) \\(World\\)');
+		});
+
+		test('Non-capturing groups should be ignored', () => {
+			let res = util.escapeRegExpGroupsLegacy('(?:Hello) (?:World)');
+			assert.equal(res, '(?:Hello) (?:World)');
+		});
+
+		test('Lookaheads should be ignored', () => {
+			let res = util.escapeRegExpGroupsLegacy('(?=Hello) (?!World)');
+			assert.equal(res, '(?=Hello) (?!World)');
+		});
+
+		test('Lookbehinds should be removed', () => {
+			let res = util.escapeRegExpGroupsLegacy('(?<=Hello) (?<!World)');
+			assert.equal(res, ' ');
+		});
+
+		test('Groups preceded by one or multiple escaped backslashes (\\) should not be ignored', () => {
+			let res = util.escapeRegExpGroupsLegacy('\\\\(Hello) \\\\\\\\(World)');
+			assert.equal(res, '\\\\(?:Hello) \\\\\\\\(?:World)');
+		});
+
+		test('Mixing lookaheads, lookbehind and groups should still behave as expected', () => {
+			let res = util.escapeRegExpGroupsLegacy('^(Hello) (?!World)|(?<=Won)derf[u]l(?:Regex){2}\A/B[c]+[0-9]*.$');
+			assert.equal('^(?:Hello) (?!World)|derf[u]l(?:Regex){2}\A/B[c]+[0-9]*.$', res);
+		});
+
 	});
 
 });

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -7,9 +7,9 @@ suite('Util Tests', () => {
 	// Test util.escapeRegExp
 	suite('Escape RegEx', () => {
 
-		test ("RegEx characters should be properly escaped", () => {
-			let res = util.escapeRegExp('^(Hello)|Wonderf[u]l(?:Regex){2}\A/B[c]+[0-9]*.$');
-			assert.equal('\\^\\(Hello\\)\\|Wonderf\\[u\\]l\\(\\?:Regex\\)\\{2\\}A\\/B\\[c\\]\\+\\[0\\-9\\]\\*\\.\\$', res);
+		test("All RegEx characters should be properly escaped", () => {
+			let res = util.escapeRegExp('^(Hello) (?!World)|(?<=Hello)\\s(?:Reg[eE]x){1}\\w+\\/[0-9]*.$');
+			assert.equal(res, '\\^\\(Hello\\) \\(\\?!World\\)\\|\\(\\?<=Hello\\)\\\\s\\(\\?:Reg\\[eE\\]x\\)\\{1\\}\\\\w\\+\\\\\\/\\[0\\-9\\]\\*\\.\\$');
 		});
 
 	});
@@ -33,9 +33,14 @@ suite('Util Tests', () => {
 				assert.equal(res, '(?:Hello) (?:World)');
 			});
 
-			test('Lookbehind and lookaheads should be ignored', () => {
-				let res = util.escapeRegExpGroups('(?=Hello) (?<!World)');
-				assert.equal(res, '(?=Hello) (?<!World)');
+			test('Lookaheads should be ignored', () => {
+				let res = util.escapeRegExpGroups('(?=Hello) (?!World)');
+				assert.equal(res, '(?=Hello) (?!World)');
+			});
+
+			test('Lookbehind should be ignored', () => {
+				let res = util.escapeRegExpGroups('(?<=Hello) (?<!World)');
+				assert.equal(res, '(?<=Hello) (?<!World)');
 			});
 
 			test('Groups preceded by one or multiple escaped backslashes (\\) should not be ignored', () => {
@@ -44,8 +49,8 @@ suite('Util Tests', () => {
 			});
 
 			test('Mixing lookaheads, lookbehind and groups should still behave as expected', () => {
-				let res = util.escapeRegExpGroups('^(Hello) (?!World)|(?<=Won)derf[u]l(?:Regex){2}\A/B[c]+[0-9]*.$');
-				assert.equal('^(?:Hello) (?!World)|(?<=Won)derf[u]l(?:Regex){2}\A/B[c]+[0-9]*.$', res);
+				let res = util.escapeRegExpGroups('^(Hello) (?!World)|(?<=Hello)\\s(?:Reg[eE]x){1}\\w+\\/[0-9]*.$');
+				assert.equal(res, '^(?:Hello) (?!World)|(?<=Hello)\\s(?:Reg[eE]x){1}\\w+\\/[0-9]*.$');
 			});
 			
 		});
@@ -85,8 +90,8 @@ suite('Util Tests', () => {
 		});
 
 		test('Mixing lookaheads, lookbehind and groups should still behave as expected', () => {
-			let res = util.escapeRegExpGroupsLegacy('^(Hello) (?!World)|(?<=Won)derf[u]l(?:Regex){2}\A/B[c]+[0-9]*.$');
-			assert.equal('^(?:Hello) (?!World)|derf[u]l(?:Regex){2}\A/B[c]+[0-9]*.$', res);
+			let res = util.escapeRegExpGroupsLegacy('^(Hello) (?!World)|(?<=Hello)\\s(?:Reg[eE]x){1}\\w+\\/[0-9]*.$');
+			assert.equal(res, '^(?:Hello) (?!World)|\\s(?:Reg[eE]x){1}\\w+\\/[0-9]*.$');
 		});
 
 	});


### PR DESCRIPTION
Added the functionality to use a proper RegEx pattern for each keyword instead of simply relying on the text field.

In detail:
- Added the "regex" object to "keywords" settings. Currently only includes the "pattern" key. If this option exists we will use the "regex.pattern" instead of the "text" field when creating the extension's search pattern.
- Altered the way that the matches are grouped to allow the existing code to recognize the new behavior.
- Altered the way that the extension's search pattern is created to allow each keyword to have it's own match group in the search results.

Additional changes:
- Updated the Readme to include examples of the added feature.
- Added tests for a few of the util functions I am using or created.
- Fixed the typo in the variable name 'mathes'.
- Removed an unused variable in a forEach loop.