### PR TITLE
add `**/vendor/**` to default exclude patterns

### DIFF
--- a/package.json
+++ b/package.json
@@ -181,6 +181,7 @@
                     "default": [
                         "**/node_modules/**",
                         "**/bower_components/**",
+                        "**/vendor/**",
                         "**/dist/**",
                         "**/build/**",
                         "**/.vscode/**",


### PR DESCRIPTION
This will ignore php dependencies installed via composer.